### PR TITLE
fix wrong repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "Utilities for Tailwind CSS",
     "repository": {
         "type": "git",
-        "url": "https://github.com/primefaces/tailwindcss-primevue.git"
+        "url": "https://github.com/primefaces/tailwindcss-primeui.git"
     },
     "license": "MIT",
     "keywords": [


### PR DESCRIPTION
The link from npmjs leads to a 404 error because "primefaces/tailwindcss-primevue" does not exist.

I assume the URL needs to be "primefaces/tailwindcss-primeui" since I'm here !