### PR TITLE
Fix repo url in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "Utilities for Tailwind CSS",
     "repository": {
         "type": "git",
-        "url": "https://github.com/primefaces/tailwindcss-primevue.git"
+        "url": "https://github.com/primefaces/tailwindcss-primeui.git"
     },
     "license": "MIT",
     "keywords": [


### PR DESCRIPTION
The repository url is `https://github.com/primefaces/tailwindcss-primeui`, not `https://github.com/primefaces/tailwindcss-primevue`. As a consequence, the Repository and Homepage links in https://www.npmjs.com/package/tailwindcss-primeui give 404s